### PR TITLE
Improve frontend conversation display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,11 +10,13 @@
   <div id="app">
     <h1>您好，我在</h1>
 
-    <div class="reply">
-      <div class="user" v-if="userText">🧑‍🗣️ {{ userText }}</div>
-      <div class="bot">
-        <span v-for="token in reply" :key="token.id" class="token">{{ token.text }}</span>
-        <span class="cursor" v-if="listening || typing">▋</span>
+    <div class="history">
+      <div v-for="(msg, idx) in history" :key="idx" :class="['message', msg.role]">
+        {{ msg.text }}
+      </div>
+      <div class="message user" v-if="userText">{{ userText }}</div>
+      <div class="message bot" v-if="reply.length">
+        <span v-for="token in reply" :key="token.id" class="token">{{ token.text }}</span><span class="cursor" v-if="listening || typing">▋</span>
       </div>
     </div>
 
@@ -31,6 +33,7 @@
     createApp({
       setup() {
         const reply = ref([])
+        const history = ref([])
         const userText = ref('')
         const recording = ref(false)
         const listening = ref(false)
@@ -62,12 +65,14 @@
             if (i >= text.length) {
               clearInterval(timer)
               typing.value = false
+              history.value.push({ role: 'bot', text })
             }
           }, 50)
         }
 
         async function startCall() {
           reply.value = []
+          history.value = []
           userText.value = ''
           recording.value = true
           listening.value = true
@@ -80,6 +85,7 @@
             if (msg.type === 'transcript') {
               userText.value = msg.data
               listening.value = false
+              history.value.push({ role: 'user', text: msg.data })
             } else if (msg.type === 'text') {
               typeReply(msg.data)
             } else if (msg.type === 'audio') {
@@ -121,7 +127,7 @@
           }
         }
 
-        return { reply, userText, recording, listening, typing, error, toggleMic }
+        return { reply, history, userText, recording, listening, typing, error, toggleMic }
       }
     }).mount('#app')
   </script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -33,26 +33,37 @@
     color: #444;
   }
 
-  .reply {
-    width: 100%;
-    padding: 1rem;
-    background: #f0f2f5;
-    border-radius: 8px;
-    margin-bottom: 1.5rem;
-    font-size: 1.1rem;
-    line-height: 1.6;
-    white-space: pre-wrap;
-    min-height: 120px;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-  }
 
-  .user {
-    width: 100%;
-    margin-bottom: 0.5rem;
-    color: #555;
-  }
+.history {
+  width: 100%;
+  padding: 1rem;
+  background: #f0f2f5;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.message {
+  max-width: 80%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  white-space: pre-wrap;
+}
+
+.message.user {
+  align-self: flex-end;
+  background-color: #daf1fd;
+}
+
+.message.bot {
+  align-self: flex-start;
+  background-color: #ededed;
+}
+
 
   .token {
     display: inline;
@@ -100,12 +111,12 @@
     margin-top: 0.5rem;
   }
 
-  @media (max-width: 768px) {
-    #app {
-      padding: 1.5rem;
-    }
-
-    .reply {
-      font-size: 1rem;
-    }
+@media (max-width: 768px) {
+  #app {
+    padding: 1.5rem;
   }
+
+  .history {
+    font-size: 1rem;
+  }
+}

--- a/worker/tts_worker.py
+++ b/worker/tts_worker.py
@@ -1,15 +1,17 @@
 import io
+import os
 import uuid
 import edge_tts
 import torch
-import torchaudio 
+import torchaudio
 
 # 可选：设置默认声音（中文女声“小小”）
 VOICE = "zh-CN-XiaoxiaoNeural"
 
 async def synthesize(text: str) -> bytes:
     tts = edge_tts.Communicate(text=text, voice=VOICE)
-    output_path = f'assets/{uuid.uuid4()}.wav'
+    os.makedirs("assets", exist_ok=True)
+    output_path = f"assets/{uuid.uuid4()}.wav"
     await tts.save(output_path)
     with open(output_path, "rb") as f:
         audio_bytes = f.read()


### PR DESCRIPTION
## Summary
- create assets directory when synthesizing TTS output
- display chat history on the page with user and bot messages
- restyle conversation layout for clarity

## Testing
- `python -m py_compile api/audio_ws.py worker/tts_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_688213dd3ce8832eb5db6c99cee11647