### PR TITLE
Implement WebRTC voice chat with interrupt

### DIFF
--- a/api/control_ws.py
+++ b/api/control_ws.py
@@ -1,0 +1,24 @@
+import json
+from fastapi import APIRouter, WebSocket
+
+from .webrtc import pcs
+
+router = APIRouter()
+
+
+@router.websocket("/ws/control")
+async def control_ws(websocket: WebSocket):
+    await websocket.accept()
+    pc_id = None
+    try:
+        while True:
+            data = await websocket.receive_text()
+            msg = json.loads(data)
+            if msg.get("type") == "register":
+                pc_id = msg.get("id")
+            elif msg.get("type") == "interrupt" and pc_id:
+                client = pcs.get(pc_id)
+                if client:
+                    client["tts"].interrupt()
+    except Exception as exc:
+        print("control ws error", exc)

--- a/api/webrtc.py
+++ b/api/webrtc.py
@@ -1,0 +1,101 @@
+import asyncio
+import json
+import uuid
+
+import av
+import webrtcvad
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.mediastreams import MediaStreamTrack
+from fastapi import APIRouter, Request
+
+from worker.asr_worker import transcribe
+from worker.nlp_worker import full_reply
+from worker.tts_worker import synthesize_stream
+
+router = APIRouter(prefix="/rtc")
+
+pcs = {}
+
+
+class TTSTrack(MediaStreamTrack):
+    kind = "audio"
+
+    def __init__(self):
+        super().__init__()
+        self.queue = asyncio.Queue()
+        self.stop_event = asyncio.Event()
+
+    async def stream_text(self, text: str):
+        self.stop_event.clear()
+        async for chunk in synthesize_stream(text):
+            if self.stop_event.is_set():
+                break
+            frame = av.AudioFrame.from_ndarray(chunk, layout="mono")
+            await self.queue.put(frame)
+        await self.queue.put(None)
+
+    def interrupt(self):
+        self.stop_event.set()
+
+    async def recv(self):
+        frame = await self.queue.get()
+        if frame is None:
+            raise asyncio.CancelledError
+        return frame
+
+
+@router.post("/offer")
+async def offer(request: Request):
+    params = await request.json()
+    offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection()
+    pc_id = str(uuid.uuid4())
+    tts_track = TTSTrack()
+    pc.addTrack(tts_track)
+    pcs[pc_id] = {"pc": pc, "tts": tts_track}
+
+    vad = webrtcvad.Vad(3)
+    audio_buffer = b""
+    frame_buffer = b""
+    silence_counter = 0
+    FRAME_DURATION_MS = 30
+    SILENCE_THRESHOLD = int(800 / FRAME_DURATION_MS)
+    SAMPLE_RATE = 16000
+    FRAME_SIZE = int(SAMPLE_RATE * FRAME_DURATION_MS / 1000) * 2
+    speech_started = False
+
+    @pc.on("track")
+    async def on_track(track):
+        nonlocal audio_buffer, frame_buffer, silence_counter, speech_started
+        if track.kind != "audio":
+            return
+        async for frame in track:
+            pcm = frame.to_ndarray().tobytes()
+            frame_buffer += pcm
+            while len(frame_buffer) >= FRAME_SIZE:
+                seg = frame_buffer[:FRAME_SIZE]
+                frame_buffer = frame_buffer[FRAME_SIZE:]
+                is_speech = vad.is_speech(seg, SAMPLE_RATE)
+                if is_speech:
+                    silence_counter = 0
+                    audio_buffer += seg
+                    speech_started = True
+                    tts_track.interrupt()
+                else:
+                    if speech_started:
+                        silence_counter += 1
+                        audio_buffer += seg
+                if speech_started and silence_counter >= SILENCE_THRESHOLD and audio_buffer:
+                    transcript = await transcribe(audio_buffer)
+                    reply_text = await full_reply(transcript)
+                    asyncio.create_task(tts_track.stream_text(reply_text))
+                    audio_buffer = b""
+                    silence_counter = 0
+                    speech_started = False
+
+    await pc.setRemoteDescription(offer)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+
+    return {"id": pc_id, "sdp": pc.localDescription.sdp, "type": pc.localDescription.type}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,35 +27,36 @@
     <div v-if="error" class="error">⚠️ {{ error }}</div>
   </div>
 
-  <script type="module">
-    import { createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
+    <script type="module">
+      import { createApp, ref } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
 
-    createApp({
-      setup() {
-        const reply = ref([])
-        const history = ref([])
-        const userText = ref('')
-        const recording = ref(false)
-        const listening = ref(false)
-        const typing = ref(false)
-        const error = ref(null)
-        let ws
-        let audioCtx
-        let processor
-        let stream
-        function playAudio(hex) {
-          const bytes = new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
-          const blob = new Blob([bytes], { type: 'audio/wav' })
-          const url = URL.createObjectURL(blob)
-          const audio = new Audio(url)
-          audio.onended = () => {
-            setTimeout(() => {
-              listening.value = true
-              userText.value = ''
-            }, 1000)
+      createApp({
+        setup() {
+          const reply = ref([])
+          const history = ref([])
+          const userText = ref('')
+          const recording = ref(false)
+          const listening = ref(false)
+          const typing = ref(false)
+          const error = ref(null)
+          let pc
+          let ctrl
+          let ttsChannel
+          let localStream
+
+          function playAudio(hex) {
+            const bytes = new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
+            const blob = new Blob([bytes], { type: 'audio/wav' })
+            const url = URL.createObjectURL(blob)
+            const audio = new Audio(url)
+            audio.onended = () => {
+              setTimeout(() => {
+                listening.value = true
+                userText.value = ''
+              }, 1000)
+            }
+            audio.play()
           }
-          audio.play()
-        }
 
         function typeReply(text) {
           reply.value = []
@@ -80,47 +81,45 @@
           listening.value = true
           error.value = null
 
-          ws = new WebSocket(`ws://${location.host}/ws/audio`)
-          ws.binaryType = 'arraybuffer'
-          ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data)
-            if (msg.type === 'transcript') {
-              userText.value = msg.data
-              listening.value = false
-              history.value.push({ role: 'user', text: msg.data })
-            } else if (msg.type === 'text') {
-              typeReply(msg.data)
-            } else if (msg.type === 'audio') {
-              playAudio(msg.data)
-            }
-          }
-          ws.onclose = () => {
-            recording.value = false
-            listening.value = false
-          }
+          ctrl = new WebSocket(`ws://${location.host}/ws/control`)
 
-          stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-          audioCtx = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 })
-          await audioCtx.audioWorklet.addModule('/static/recorderWorklet.js')
-          const source = audioCtx.createMediaStreamSource(stream)
-          processor = new AudioWorkletNode(audioCtx, 'recorder')
-          processor.port.onmessage = (e) => {
-            if (!recording.value || !listening.value) return
-            if (ws.readyState === WebSocket.OPEN) {
-              ws.send(e.data.buffer)
-            } else {
-              console.warn('WebSocket not open:', ws.readyState)
+          ctrl.onopen = async () => {
+            pc = new RTCPeerConnection()
+            ttsChannel = pc.createDataChannel('tts')
+            ttsChannel.onmessage = (e) => {
+              const msg = JSON.parse(e.data)
+              if (msg.type === 'transcript') {
+                userText.value = msg.data
+                listening.value = false
+                history.value.push({ role: 'user', text: msg.data })
+              } else if (msg.type === 'text') {
+                typeReply(msg.data)
+              } else if (msg.type === 'audio') {
+                playAudio(msg.data)
+              }
             }
+
+            localStream = await navigator.mediaDevices.getUserMedia({ audio: true })
+            localStream.getTracks().forEach(t => pc.addTrack(t, localStream))
+
+            const offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            const resp = await fetch('/rtc/offer', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(pc.localDescription)
+            })
+            const ans = await resp.json()
+            await pc.setRemoteDescription(new RTCSessionDescription(ans))
+            ctrl.send(JSON.stringify({ type: 'register', id: ans.id }))
           }
-          source.connect(processor)
-          processor.connect(audioCtx.destination)
         }
 
         function stopCall() {
-          ws?.close()
-          processor?.disconnect()
-          stream?.getTracks().forEach(t => t.stop())
-          audioCtx?.close()
+          ctrl?.close()
+          pc?.close()
+          localStream?.getTracks().forEach(t => t.stop())
           recording.value = false
         }
 

--- a/main.py
+++ b/main.py
@@ -4,10 +4,14 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from api.routes import router as api_router
 from api.audio_ws import router as ws_router
+from api.webrtc import router as rtc_router
+from api.control_ws import router as ctrl_router
 
 app = FastAPI()
 app.include_router(api_router)
 app.include_router(ws_router)
+app.include_router(rtc_router)
+app.include_router(ctrl_router)
 
 app.mount("/static", StaticFiles(directory="frontend"), name="static")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ torchaudio
 webrtcvad
 uvicorn
 soundfile
+aiortc

--- a/worker/nlp_worker.py
+++ b/worker/nlp_worker.py
@@ -3,24 +3,27 @@ from zhipuai import ZhipuAI
 BIGMODEL_API_KEY = "fe28433d565d40a5a1806ab43719e504.HHwmOUiDA4XPCDkk"
 client = ZhipuAI(api_key=BIGMODEL_API_KEY)
 
+
+def format_messages(user_text: str):
+    return [
+        {"role": "user", "content": "用中文和我对话"},
+        {"role": "user", "content": user_text},
+    ]
+
+
 async def full_reply(user_text: str) -> str:
     response = client.chat.completions.create(
-    model="glm-4-plus",  # 请填写您要调用的模型名称
-    messages=[
-        {"role": "user", "content": "用中文和我对话"},
-        {"role": "user", "content": user_text}
-    ],
+        model="glm-4-plus",
+        messages=format_messages(user_text),
     )
     return response.choices[0].message.content
 
 
 async def stream_reply(user_text: str):
     response = client.chat.completions.create(
-    model="glm-4-plus",  # 请填写您要调用的模型名称
-    messages=[
-        {"role": "user", "content": user_text},
-    ],
-    stream=True,
+        model="glm-4-plus",
+        messages=format_messages(user_text),
+        stream=True,
     )
     for chunk in response:
         yield chunk.choices[0].delta

--- a/worker/tts_worker.py
+++ b/worker/tts_worker.py
@@ -1,21 +1,23 @@
-import io
 import os
 import uuid
 import edge_tts
-import torch
-import torchaudio
 
-# 可选：设置默认声音（中文女声“小小”）
 VOICE = "zh-CN-XiaoxiaoNeural"
 
+
 async def synthesize(text: str) -> bytes:
+    """Synthesize text to audio and return WAV bytes."""
     tts = edge_tts.Communicate(text=text, voice=VOICE)
     os.makedirs("assets", exist_ok=True)
     output_path = f"assets/{uuid.uuid4()}.wav"
     await tts.save(output_path)
     with open(output_path, "rb") as f:
-        audio_bytes = f.read()
+        return f.read()
 
-    return audio_bytes
 
-   
+async def synthesize_stream(text: str):
+    """Asynchronously yield WAV byte chunks for streaming playback."""
+    communicator = edge_tts.Communicate(text=text, voice=VOICE)
+    async for chunk in communicator.stream():
+        if chunk["type"] == "audio":
+            yield chunk["data"]


### PR DESCRIPTION
## Summary
- remove leftover shell prompts and clean up worker files
- implement streaming TTS helper
- add WebRTC offer endpoint and interruptable `TTSTrack`
- add control websocket for interrupt commands
- update frontend to use WebRTC and the control websocket
- include new routes in server startup
- update requirements with aiortc

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68830451df28832e860b8280c06d3b6d